### PR TITLE
投稿にエリアをタグ付けできるようにする

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -77,6 +77,6 @@ class PlacesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def place_params
-      params.require(:place).permit(:name, :description, :address, :latitude, :longitude, images:[])
+      params.require(:place).permit(:name, :description, :area_id, :address, :latitude, :longitude, images:[])
     end
 end

--- a/app/views/places/_form.html.erb
+++ b/app/views/places/_form.html.erb
@@ -21,6 +21,28 @@
     <%= form.text_field :description %>
   </div>
 
+<!-- parkとarea
+  <div class="field">
+    <%= form.label :park %>
+    <%= form.collection_select :park_id, Park.all, :id, :name, :include_blank => true %>
+  </div>
+
+  <div class="field">
+    <%= form.label :area %>
+    <%= form.collection_select :area_id, Area.all, :id, :name, :include_blank => true %>
+  </div> -->
+
+  <div class="field">
+    <%= form.label :park %>
+    <%= form.collection_select :park_id, Park.all, :id, :name,  {prompt: "パークを選択してください"}, {class: 'park'} %>
+  </div>
+
+
+  <div class="field">
+    <%= form.label :area %>
+    <%= form.select :area_id, options_for_select(Area.all.map{|area|[area[:name], area[:id], {'data-val'=>area[:park_id]}]}), {prompt: "エリアを選択してください"}, {class: 'area'} %>
+  </div>
+
   <div class="field">
     <%= form.hidden_field :address %>
   </div>
@@ -44,3 +66,56 @@
     <%= form.submit %>
   </div>
 <% end %>
+
+
+<script type="text/javascript">
+
+  var $areas = $('.park'); //都道府県の要素を変数に入れます。
+  var options = $('.area').find("option");
+
+  $('.park').change(function() {
+
+      //エリアセレクトの初期化
+    $.each(options,function(index,value){
+      $(value).removeAttr("selected");
+      if($(value).data("val") == "default"){
+          $(value).attr("selected","selected");
+      }
+      $(value).show();
+    });
+
+    //選択されたパークのvalueを取得し変数に入れる
+    var val1 = $(this).val();
+
+    //エリア選択肢カウンタ
+    var option_count = 0;
+    //エリア選択肢が１つだったとき用の保存変数
+    var option_select = "";
+
+      //エリア選択肢の表示切り替え
+    $.each(options,function(index,value){
+      var area_option = $(value);
+      if(area_option.data("val") == "default"){
+        //初期値選択肢用（-- エリア --）
+        area_option.attr("selected","selected");
+      }else if(area_option.data("val") == val1){
+        //選択されたパークに当てはまる場合はカウントを増やし、option_selectに格納
+        option_count++;
+        option_select = area_option;
+      }else{
+        //選択されたパークにあてはまらない場合は、隠す
+        area_option.hide();
+      }
+    });
+
+    //エリアの選択肢が１つしかない場合は、自動的に選択された状態に変更
+    if(option_count == 1){
+      option_select.attr("selected","selected");
+    }
+
+    //エリアセレクトを選択可能に
+    $('.area').prop("disabled", false);
+
+  });
+
+</script>

--- a/app/views/places/_form.html.erb
+++ b/app/views/places/_form.html.erb
@@ -21,22 +21,10 @@
     <%= form.text_field :description %>
   </div>
 
-<!-- parkとarea
-  <div class="field">
-    <%= form.label :park %>
-    <%= form.collection_select :park_id, Park.all, :id, :name, :include_blank => true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :area %>
-    <%= form.collection_select :area_id, Area.all, :id, :name, :include_blank => true %>
-  </div> -->
-
   <div class="field">
     <%= form.label :park %>
     <%= form.collection_select :park_id, Park.all, :id, :name,  {prompt: "パークを選択してください"}, {class: 'park'} %>
   </div>
-
 
   <div class="field">
     <%= form.label :area %>
@@ -69,6 +57,9 @@
 
 
 <script type="text/javascript">
+
+  // 初期表示時に、エリア選択を不可にする
+  $('.area').prop("disabled", true);
 
   var $areas = $('.park'); //都道府県の要素を変数に入れます。
   var options = $('.area').find("option");


### PR DESCRIPTION
タグ付けではなく、データベースにarea_idカラムを増やして実装
パークのプルダウン→エリアのプルダウンの順に選択してスポットを登録